### PR TITLE
modified call method in QMeasureDensityEig

### DIFF
--- a/qmc/tf/layers.py
+++ b/qmc/tf/layers.py
@@ -488,13 +488,11 @@ class QMeasureDensityEig(tf.keras.layers.Layer):
         eig_val = eig_val / tf.reduce_sum(eig_val)
         rho_h = tf.matmul(eig_vec,
                           tf.linalg.diag(tf.sqrt(eig_val)))
-        rho = tf.matmul(
-            rho_h,
-            tf.transpose(rho_h, conjugate=True))
+        rho_h = tf.matmul(oper, rho_h)
         rho_res = tf.einsum(
-            '...ik, km, ...mi -> ...',
-            oper, rho, oper,
-            optimize='optimal')  # shape (b, nx, ny, nx, ny)
+            '...ik, ki... -> ...',
+            rho_h, tf.transpose(rho_h, conjugate=True), 
+            optimize='optimal') # shape (b,)
         return rho_res
 
     def set_rho(self, rho):


### PR DESCRIPTION
Changed the order of the matrices multiplication to reduce the complexity of the call() method in class QMeasureDensityEig, 
I verified that the .call() method returns the same value of the original version for various entries.