### PR TITLE
Changed part of the .call in class QMDEig

### DIFF
--- a/qmc/tf/layers.py
+++ b/qmc/tf/layers.py
@@ -490,8 +490,8 @@ class QMeasureDensityEig(tf.keras.layers.Layer):
                           tf.linalg.diag(tf.sqrt(eig_val)))
         rho_h = tf.matmul(oper, rho_h)
         rho_res = tf.einsum(
-            '...ik, ki... -> ...',
-            rho_h, tf.transpose(rho_h, conjugate=True), 
+            '...ik, ...ik -> ...',
+            rho_h, tf.math.conj(rho_h), 
             optimize='optimal') # shape (b,)
         return rho_res
 


### PR DESCRIPTION
I found that the recent proposed method to reduce complexity of the call in QMeasureDensityEig is not efficient enough when the number of eigenvalues is not small, 
Here I changed again the .call in layer QMDEig method with a more efficient implementation, 
The call method leads the same results as the original method with randomFeatures and ComplexRandomFeautures.