### PR TITLE
Change .call from QMDensityEig Layer

### DIFF
--- a/qmc/tf/layers.py
+++ b/qmc/tf/layers.py
@@ -478,19 +478,15 @@ class QMeasureDensityEig(tf.keras.layers.Layer):
         self.built = True
 
     def call(self, inputs):
-        oper = tf.einsum(
-            '...i,...j->...ij',
-            inputs, tf.math.conj(inputs),
-            optimize='optimal') # shape (b, nx, nx)
         norms = tf.expand_dims(tf.linalg.norm(self.eig_vec, axis=0), axis=0)
         eig_vec = self.eig_vec / norms
         eig_val = tf.keras.activations.relu(self.eig_val)
         eig_val = eig_val / tf.reduce_sum(eig_val)
         rho_h = tf.matmul(eig_vec,
                           tf.linalg.diag(tf.sqrt(eig_val)))
-        rho_h = tf.matmul(oper, rho_h)
+        rho_h = tf.matmul(tf.math.conj(inputs), rho_h)
         rho_res = tf.einsum(
-            '...ik, ...ik -> ...',
+            '...i, ...i -> ...',
             rho_h, tf.math.conj(rho_h), 
             optimize='optimal') # shape (b,)
         return rho_res


### PR DESCRIPTION
I propose changing the .call method in QMDensityEig layer, the reason is that originally the layer computes tr ( |psi><psi|(rho_train)|psi><psi| ) which is equivalent to <psi|(rho_train)|psi> , this reduces the complexity of the algorithm. I have checked that the outputs of the .call layer is the same between the original method and the proposed method for random features and complex random features.