### PR TITLE
Library-like interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,23 @@
 
+[![Paper1](https://img.shields.io/badge/paper-arXiv%3A2004.01227-red)](https://arxiv.org/abs/2004.01227)
+[![Paper2](https://img.shields.io/badge/paper-arXiv%3A2102.04394-red)](https://arxiv.org/abs/2102.04394)
+
 Quantum Measurement Classification
 ============================================================
 
-An implementation of Quantum Measurement Classification based on the paper:
+Implementation of some machine learning algorithms using density matrices from quantum mechanics. Particularly, the library provides support for
 
-Supervised Learning with Quantum Measurements ([arxiv](https://arxiv.org/abs/2004.01227))
+- Density matrix kernel density estimation
+- Density matrix kernel density classification
+- Quantum measurement classification
+- Quantum measurement regression
 
+# Getting Started
+
+You can install the most recent version of the library with
+
+```zsh
+pip install git+https://github.com/fagonzalezo/qmc.git
+```
+
+Check our [examples](https://github.com/fagonzalezo/qmc/tree/master/examples) to see what you can do!

--- a/qmc/__init__.py
+++ b/qmc/__init__.py
@@ -1,0 +1,1 @@
+from .tf import *

--- a/qmc/tf/__init__.py
+++ b/qmc/tf/__init__.py
@@ -1,0 +1,2 @@
+from .layers import *
+from .models import *

--- a/qmc/tf/models.py
+++ b/qmc/tf/models.py
@@ -3,7 +3,7 @@ Quantum Measurement Classfiication Models
 '''
 
 import tensorflow as tf
-import qmc.tf.layers as layers
+from . import layers
 
 class QMClassifier(tf.keras.Model):
     """

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+from setuptools import setup
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setup(
+    name="qmc",
+    packages=["qmc"],
+    version='0.0.0',
+    description="Implementation of some machine learning techniques based on density matrices",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    author="Fabio A. González et al.",
+    author_email="fagonzalezo@unal.edu.co",
+    license="GNUv3",
+    install_requires=["scipy", "numpy==1.19.2", "scikit-learn", "tensorflow >= 2.2.0", "typeguard"],
+    python_requires='>=3.6'
+)


### PR DESCRIPTION
This PR sets files to create a library out of qmc. Now, qmc is pip installable, which might be good for people wanting to easily use this library, as it is not customary to import a folder, but to include that folder in the python packages, so that from any folder people can do a `from qmc import *`.